### PR TITLE
fix: 同じタブ内で表示する設定が無効の場合に、ユーザーメンション起因でエラーログが発生していたのを修正

### DIFF
--- a/src/features/target-blank/contentScripts/setTargetBlank.ts
+++ b/src/features/target-blank/contentScripts/setTargetBlank.ts
@@ -15,12 +15,14 @@ export const setTargetBlank = (settings: TargetBlankSettings) => {
             return
         }
         try {
-            const { host } = new URL(element.href)
+            const href = element.isUserMention || element.isSameSiteLink ? `${location.origin}${element.href}` : element.href
+            const { host } = new URL(href)
             if (excludeUrlList.includes(host)) {
                 return
             }
-        } catch (e) { 
-            console.log(e);
+        } catch (e) {
+            console.log(element.href);
+            console.error(e);
         }
         element.setTargetBlankAttribute(element.rawElement)
     })

--- a/src/features/target-blank/contentScripts/setTargetBlank.ts
+++ b/src/features/target-blank/contentScripts/setTargetBlank.ts
@@ -21,7 +21,7 @@ export const setTargetBlank = (settings: TargetBlankSettings) => {
                 return
             }
         } catch (e) {
-            console.log(element.href);
+            console.error("Caused URL:", element.href);
             console.error(e);
         }
         element.setTargetBlankAttribute(element.rawElement)


### PR DESCRIPTION
# 概要

タイトルの通り。

**実際に発生していたエラーログ**

![image](https://user-images.githubusercontent.com/16623885/159176699-e23a5a59-6b59-4f74-9062-4f12150ae00e.png)

# 対応

- user-mention / same-site-link の場合に `location.origin` を追加するように条件式を追加
- エラー発生時に何が原因かわかりやすくするために、原因になったURLを表示するように機能追加