### PR TITLE
test: ID出力用のsha256関数のテストを追加

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -7,7 +7,7 @@ on:
       - "lib/**"
 
 jobs:
-  build:
+  run_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "src/**"
+      - "lib/**"
 
 jobs:
   build:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -125,7 +125,9 @@ export default {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: [
+    "<rootDir>/lib/test/jest.setup.js"
+  ],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/lib/test/jest.setup.js
+++ b/lib/test/jest.setup.js
@@ -1,0 +1,2 @@
+import { webcrypto } from "crypto";
+global.crypto = webcrypto

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "package:firefox": "echo \"=== つかえないよ！！===\"; web-ext build -s dist-firefox --overwrite-dest",
     "package:chrome": "yarn clean:chrome && yarn build:chrome && zip -r packaged/dist-chrome.zip dist-chrome",
     "test": "jest",
-    "test:ci": "jest --ci --maxWorkers=4 --runInBand"
+    "test:ci": "jest --ci --runInBand"
   },
   "dependencies": {
     "@types/chrome": "^0.0.178",

--- a/src/features/target-blank/utils/sha256.test.ts
+++ b/src/features/target-blank/utils/sha256.test.ts
@@ -1,0 +1,25 @@
+import { sha256 } from "./sha256";
+
+describe('util > sha256', () => {
+
+    test('sha256 関数が空文字を元に複数回呼んでも同じIDを出力できる', async () => {
+        const expected = await sha256("")
+        const actual = await sha256("")
+
+        expect(expected).toEqual(actual)
+    })
+
+    test('sha256 関数が同じhost名を元に複数回呼んでも同じIDを出力できる', async () => {
+        const expected = await sha256("example.com")
+        const actual = await sha256("example.com")
+
+        expect(expected).toEqual(actual)
+    })
+
+    test('sha256 関数が異なるhost名を元に複数回呼ぶと異なるIDを出力できる', async () => {
+        const expected = await sha256("example.com")
+        const actual = await sha256("a.example.com")
+
+        expect(expected).not.toEqual(actual)
+    })
+})


### PR DESCRIPTION
# 概要

- test: ID出力用のsha256関数のテストを追加
- chore: GitHub Actionsの実行トリガー範囲にlibディレクトリを追加
- chore: Jestでwebcryptoが使えないため、設定を追加

# 参照

- https://nodejs.org/api/webcrypto.html#digest
- https://github.com/jsdom/jsdom/issues/1612
- https://stackoverflow.com/questions/52612122/how-to-use-jest-to-test-functions-using-crypto-or-window-mscrypto