### PR TITLE
feat: プレビューモードでもtarget-blankが効くように機能追加

### DIFF
--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -1,9 +1,11 @@
 import { setTargetBlank } from "../features/target-blank/contentScripts"
+import { startPreviewBoxObserve } from "../features/target-blank/contentScripts/startPreviewBoxObserve";
 import { getSettingsAboutTargetBlank } from "../features/target-blank/utils/getSettingsAboutTargetBlank";
 
 (async () => {
     console.log("Running 木べら！！ on feature of TargetBlank");
     
     const settings = await getSettingsAboutTargetBlank()
+    startPreviewBoxObserve(settings)
     await setTargetBlank(settings)
 })()

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -4,8 +4,10 @@ import { getSettingsAboutTargetBlank } from "../features/target-blank/utils/getS
 
 (async () => {
     console.log("Running 木べら！！ on feature of TargetBlank");
-    
+
     const settings = await getSettingsAboutTargetBlank()
-    startPreviewBoxObserve(settings)
+    if (settings.isOpenOtherTabInPreview) {
+        startPreviewBoxObserve(settings)
+    }
     await setTargetBlank(settings)
 })()

--- a/src/features/target-blank/components/settings.tsx
+++ b/src/features/target-blank/components/settings.tsx
@@ -7,6 +7,7 @@ export const Settings: React.FC = () => {
   const initState: State = {
     alwaysOpenOtherTab: true,
     inKibelaLinkOpenSameTab: false,
+    isOpenOtherTabInPreview: true,
     excludeUrlInput: '',
     excludeUrlList: [],
     excludeUrlInputValidation: '',
@@ -22,11 +23,13 @@ export const Settings: React.FC = () => {
     setChromeStorage({
       alwaysOpenOtherTab: localSettings.alwaysOpenOtherTab,
       inKibelaLinkOpenSameTab: localSettings.inKibelaLinkOpenSameTab,
+      isOpenOtherTabInPreview: localSettings.isOpenOtherTabInPreview,
       excludeUrlList: localSettings.excludeUrlList,
     });
   }, [
     localSettings.alwaysOpenOtherTab,
     localSettings.inKibelaLinkOpenSameTab,
+    localSettings.isOpenOtherTabInPreview,
     localSettings.excludeUrlList,
   ]);
 

--- a/src/features/target-blank/components/settings.tsx
+++ b/src/features/target-blank/components/settings.tsx
@@ -61,6 +61,27 @@ export const Settings: React.FC = () => {
         <input
           className="mx-2"
           type="checkbox"
+          name="is-open-other-tab-in-preview"
+          id="is-open-other-tab-in-preview"
+          checked={localSettings.isOpenOtherTabInPreview}
+          onChange={() =>
+            dispatch({
+              type: 'setIsOpenOtherTabInPreview',
+              payload: !localSettings.isOpenOtherTabInPreview,
+            })
+          }
+        />
+        <label
+          className="leading-tight hover:cursor-pointer"
+          htmlFor="is-open-other-tab-in-preview"
+        >
+          記事編集プレビュー画面のリンクを別タブで開く
+        </label>
+      </div>
+      <div className="pb-2 text-base">
+        <input
+          className="mx-2"
+          type="checkbox"
           name="in-kibela-link-open-same-tab"
           id="in-kibela-link-open-same-tab"
           checked={localSettings.inKibelaLinkOpenSameTab}
@@ -76,27 +97,6 @@ export const Settings: React.FC = () => {
           htmlFor="in-kibela-link-open-same-tab"
         >
           Kibela内の別記事 / ユーザーページへのリンクは同じタブで開く
-        </label>
-      </div>
-      <div className="pb-2 text-base">
-        <input
-          className="mx-2"
-          type="checkbox"
-          name="is-open-other-tab-in-preview"
-          id="is-open-other-tab-in-preview"
-          checked={localSettings.isOpenOtherTabInPreview}
-          onChange={() =>
-            dispatch({
-              type: 'setIsOpenOtherTabInPreview',
-              payload: !localSettings.isOpenOtherTabInPreview,
-            })
-          }
-        />
-        <label
-          className="leading-tight hover:cursor-pointer"
-          htmlFor="is-open-other-tab-in-preview"
-        >
-          記事編集プレビュー画面でも別タブで開く
         </label>
       </div>
       <div className="mx-auto w-11/12 border-b border-gray-300">

--- a/src/features/target-blank/components/settings.tsx
+++ b/src/features/target-blank/components/settings.tsx
@@ -57,7 +57,7 @@ export const Settings: React.FC = () => {
           デフォルトでリンクを別タブで開く
         </label>
       </div>
-      <div className="pb-2 text-base">
+      <div className="text-base">
         <input
           className="mx-2"
           type="checkbox"
@@ -76,6 +76,27 @@ export const Settings: React.FC = () => {
           htmlFor="in-kibela-link-open-same-tab"
         >
           Kibela内の別記事 / ユーザーページへのリンクは同じタブで開く
+        </label>
+      </div>
+      <div className="pb-2 text-base">
+        <input
+          className="mx-2"
+          type="checkbox"
+          name="is-open-other-tab-in-preview"
+          id="is-open-other-tab-in-preview"
+          checked={localSettings.isOpenOtherTabInPreview}
+          onChange={() =>
+            dispatch({
+              type: 'setIsOpenOtherTabInPreview',
+              payload: !localSettings.isOpenOtherTabInPreview,
+            })
+          }
+        />
+        <label
+          className="leading-tight hover:cursor-pointer"
+          htmlFor="is-open-other-tab-in-preview"
+        >
+          記事編集プレビュー画面でも別タブで開く
         </label>
       </div>
       <div className="mx-auto w-11/12 border-b border-gray-300">

--- a/src/features/target-blank/contentScripts/domAdapter.ts
+++ b/src/features/target-blank/contentScripts/domAdapter.ts
@@ -1,4 +1,4 @@
-import { TargetBlankSettings } from "../types"
+import { DOMElement, EffectsDomFunction, TargetBlankSettings } from "../types"
 
 export const SELECTOR = {
     main: ".markdown-body a[href]",
@@ -6,19 +6,7 @@ export const SELECTOR = {
     previewWrapper: ".previewBox > div",
 }
 
-export type DOMElement = {
-    href: string,
-    className: string,
-    idName: string,
-    isSameSiteLink: boolean,
-    isUserMention: boolean,
-    isAnchorLink: boolean,
-    hasTargetBlank: boolean,
-    setTargetBlankAttribute: (e: Element) => void,
-    rawElement: Element,
-}
-
-export const convertDomElement = (elementList: NodeListOf<Element>) => {
+export const convertDomElement = (elementList: NodeListOf<Element>): DOMElement[] => {
     const temporaryList: DOMElement[] = []
     elementList.forEach(e => {
         const className = e.getAttribute("class") ?? ""
@@ -45,8 +33,7 @@ export const convertDomElement = (elementList: NodeListOf<Element>) => {
     return temporaryList
 }
 
-
-export const getPreviewObserver = ({ settings, effectToDom }: { settings: TargetBlankSettings, effectToDom: Function }) => {
+export const getPreviewObserver = ({ settings, effectsDom }: { settings: TargetBlankSettings, effectsDom: EffectsDomFunction }) => {
     return new MutationObserver(_ => {
         const rawElements = document.querySelectorAll(SELECTOR.preview)
         let elements: DOMElement[] = []
@@ -55,6 +42,6 @@ export const getPreviewObserver = ({ settings, effectToDom }: { settings: Target
             elements = convertDomElement(rawElements)
         }
 
-        effectToDom(elements, settings)
+        effectsDom({ elements, settings })
     })
 }

--- a/src/features/target-blank/contentScripts/domAdapter.ts
+++ b/src/features/target-blank/contentScripts/domAdapter.ts
@@ -1,6 +1,12 @@
-export const domElements: DOMElement[] = []
+import { TargetBlankSettings } from "../types"
 
-type DOMElement = {
+type TargetType = "main" | "preview"
+export const SELECTOR: { [key in TargetType]: string } = {
+    main: ".markdown-body a[href]",
+    preview: ".previewBox > div"
+}
+
+export type DOMElement = {
     href: string,
     className: string,
     idName: string,
@@ -11,27 +17,51 @@ type DOMElement = {
     setTargetBlankAttribute: (e: Element) => void,
     rawElement: Element,
 }
-const setTargetBlankAttribute = (element: Element) => {
-    element.setAttribute("target", "_blank")
-    element.setAttribute("rel", "noopener noreferrer")
+
+export const convertDomElement = (elementList: NodeListOf<Element>) => {
+    const temporaryList: DOMElement[] = []
+    elementList.forEach(e => {
+        const className = e.getAttribute("class") ?? ""
+        const isAnchorLink = className.includes("anchor")
+        const isUserMention = className.includes("user-mention")
+        const isSameSiteLink = className.includes("entry-titleWithIcon")
+
+        temporaryList.push({
+            href: e.getAttribute("href") ?? "",
+            className: e.getAttribute("class") ?? "",
+            idName: e.getAttribute("id") ?? "",
+            hasTargetBlank: e.getAttribute("target") === "_blank",
+            isSameSiteLink,
+            isUserMention,
+            isAnchorLink,
+            rawElement: e,
+            setTargetBlankAttribute: (element: Element) => {
+                element.setAttribute("target", "_blank")
+                element.setAttribute("rel", "noopener noreferrer")
+            },
+        })
+    })
+
+    return temporaryList
 }
 
-const allATag = document.querySelectorAll(".markdown-body a[href]")
-allATag.forEach(e => {
-    const className = e.getAttribute("class") ?? ""
-    const isAnchorLink = className.includes("anchor")
-    const isUserMention = className.includes("user-mention")
-    const isSameSiteLink = className.includes("entry-titleWithIcon")
 
-    domElements.push({
-        href: e.getAttribute("href") ?? "",
-        className: e.getAttribute("class") ?? "",
-        idName: e.getAttribute("id") ?? "",
-        hasTargetBlank: e.getAttribute("target") === "_blank",
-        isSameSiteLink,
-        isUserMention,
-        isAnchorLink,
-        setTargetBlankAttribute,
-        rawElement: e,
+export const getPreviewObserver = ({ settings, effectToDom }: { settings: TargetBlankSettings, effectToDom: Function }) => {
+    return new MutationObserver(records => {
+        const [_before, after] = records
+        const firstChild = after.addedNodes[0] as Element
+
+        if (firstChild && firstChild.classList.contains("markdown-body")) {
+            const rawElements = firstChild.querySelectorAll("a[href]")
+            let elements: DOMElement[] = []
+
+            if (rawElements) {
+                elements = convertDomElement(rawElements)
+            }
+            
+            effectToDom(elements, settings)
+        } else if (firstChild && firstChild.classList.contains("previewBox-placeholder")) {
+            console.log("preview disable");
+        }
     })
-})
+}

--- a/src/features/target-blank/contentScripts/domAdapter.ts
+++ b/src/features/target-blank/contentScripts/domAdapter.ts
@@ -1,9 +1,9 @@
 import { TargetBlankSettings } from "../types"
 
-type TargetType = "main" | "preview"
-export const SELECTOR: { [key in TargetType]: string } = {
+export const SELECTOR = {
     main: ".markdown-body a[href]",
-    preview: ".previewBox > div"
+    preview: ".previewBox .markdown-body a[href]",
+    previewWrapper: ".previewBox > div",
 }
 
 export type DOMElement = {
@@ -47,21 +47,14 @@ export const convertDomElement = (elementList: NodeListOf<Element>) => {
 
 
 export const getPreviewObserver = ({ settings, effectToDom }: { settings: TargetBlankSettings, effectToDom: Function }) => {
-    return new MutationObserver(records => {
-        const [_before, after] = records
-        const firstChild = after.addedNodes[0] as Element
+    return new MutationObserver(_ => {
+        const rawElements = document.querySelectorAll(SELECTOR.preview)
+        let elements: DOMElement[] = []
 
-        if (firstChild && firstChild.classList.contains("markdown-body")) {
-            const rawElements = firstChild.querySelectorAll("a[href]")
-            let elements: DOMElement[] = []
-
-            if (rawElements) {
-                elements = convertDomElement(rawElements)
-            }
-            
-            effectToDom(elements, settings)
-        } else if (firstChild && firstChild.classList.contains("previewBox-placeholder")) {
-            console.log("preview disable");
+        if (rawElements) {
+            elements = convertDomElement(rawElements)
         }
+
+        effectToDom(elements, settings)
     })
 }

--- a/src/features/target-blank/contentScripts/effectsDom.ts
+++ b/src/features/target-blank/contentScripts/effectsDom.ts
@@ -1,0 +1,28 @@
+import { EffectsDomFunction } from "../types"
+
+export const effectsDom: EffectsDomFunction = ({ elements, settings }) => {
+    const excludeUrlList = settings.excludeUrlList.map(excludeUrl => excludeUrl.host)
+
+    elements.forEach(element => {
+        if (!settings.alwaysOpenOtherTab) {
+            return
+        }
+        if (settings.inKibelaLinkOpenSameTab && (element.isUserMention || element.isSameSiteLink)) {
+            return
+        }
+        if (element.isAnchorLink) {
+            return
+        }
+        try {
+            const href = element.isUserMention || element.isSameSiteLink ? `${location.origin}${element.href}` : element.href
+            const { host } = new URL(href)
+            if (excludeUrlList.includes(host)) {
+                return
+            }
+        } catch (e) {
+            console.error("Caused URL:", element.href);
+            console.error(e);
+        }
+        element.setTargetBlankAttribute(element.rawElement)
+    })
+}

--- a/src/features/target-blank/contentScripts/setTargetBlank.ts
+++ b/src/features/target-blank/contentScripts/setTargetBlank.ts
@@ -1,10 +1,30 @@
 import { TargetBlankSettings } from "../types"
-import { domElements } from "./domAdapter"
+import { convertDomElement, DOMElement, getPreviewObserver, SELECTOR } from "./domAdapter"
 
 export const setTargetBlank = (settings: TargetBlankSettings) => {
+    const observer = getPreviewObserver({ settings, effectToDom })
+    const previewBox = document.querySelector(SELECTOR.preview);
+
+    if (previewBox) {
+        observer.observe(previewBox, {
+            childList: true,
+        })
+    }
+
+    const rawElements = document.querySelectorAll(SELECTOR.main)
+    let elements: DOMElement[] = []
+
+    if (rawElements) {
+        elements = convertDomElement(rawElements)
+    }
+
+    effectToDom(elements, settings)
+}
+
+const effectToDom = (elements: DOMElement[], settings: TargetBlankSettings) => {
     const excludeUrlList = settings.excludeUrlList.map(excludeUrl => excludeUrl.host)
 
-    domElements.forEach(element => {
+    elements.forEach(element => {
         if (!settings.alwaysOpenOtherTab) {
             return
         }

--- a/src/features/target-blank/contentScripts/setTargetBlank.ts
+++ b/src/features/target-blank/contentScripts/setTargetBlank.ts
@@ -3,11 +3,12 @@ import { convertDomElement, DOMElement, getPreviewObserver, SELECTOR } from "./d
 
 export const setTargetBlank = (settings: TargetBlankSettings) => {
     const observer = getPreviewObserver({ settings, effectToDom })
-    const previewBox = document.querySelector(SELECTOR.preview);
+    const previewBox = document.querySelector(SELECTOR.previewWrapper);
 
     if (previewBox) {
         observer.observe(previewBox, {
             childList: true,
+            subtree: true
         })
     }
 

--- a/src/features/target-blank/contentScripts/setTargetBlank.ts
+++ b/src/features/target-blank/contentScripts/setTargetBlank.ts
@@ -1,17 +1,8 @@
-import { TargetBlankSettings } from "../types"
-import { convertDomElement, DOMElement, getPreviewObserver, SELECTOR } from "./domAdapter"
+import { DOMElement, TargetBlankSettings } from "../types"
+import { convertDomElement, SELECTOR } from "./domAdapter"
+import { effectsDom } from "./effectsDom";
 
 export const setTargetBlank = (settings: TargetBlankSettings) => {
-    const previewBox = document.querySelector(SELECTOR.previewWrapper);
-
-    if (previewBox) {
-        const observer = getPreviewObserver({ settings, effectToDom })
-        observer.observe(previewBox, {
-            childList: true,
-            subtree: true
-        })
-    }
-
     const rawElements = document.querySelectorAll(SELECTOR.main)
     let elements: DOMElement[] = []
 
@@ -19,32 +10,5 @@ export const setTargetBlank = (settings: TargetBlankSettings) => {
         elements = convertDomElement(rawElements)
     }
 
-    effectToDom(elements, settings)
-}
-
-const effectToDom = (elements: DOMElement[], settings: TargetBlankSettings) => {
-    const excludeUrlList = settings.excludeUrlList.map(excludeUrl => excludeUrl.host)
-
-    elements.forEach(element => {
-        if (!settings.alwaysOpenOtherTab) {
-            return
-        }
-        if (settings.inKibelaLinkOpenSameTab && (element.isUserMention || element.isSameSiteLink)) {
-            return
-        }
-        if (element.isAnchorLink) {
-            return
-        }
-        try {
-            const href = element.isUserMention || element.isSameSiteLink ? `${location.origin}${element.href}` : element.href
-            const { host } = new URL(href)
-            if (excludeUrlList.includes(host)) {
-                return
-            }
-        } catch (e) {
-            console.error("Caused URL:", element.href);
-            console.error(e);
-        }
-        element.setTargetBlankAttribute(element.rawElement)
-    })
+    effectsDom({ elements, settings })
 }

--- a/src/features/target-blank/contentScripts/setTargetBlank.ts
+++ b/src/features/target-blank/contentScripts/setTargetBlank.ts
@@ -2,10 +2,10 @@ import { TargetBlankSettings } from "../types"
 import { convertDomElement, DOMElement, getPreviewObserver, SELECTOR } from "./domAdapter"
 
 export const setTargetBlank = (settings: TargetBlankSettings) => {
-    const observer = getPreviewObserver({ settings, effectToDom })
     const previewBox = document.querySelector(SELECTOR.previewWrapper);
 
     if (previewBox) {
+        const observer = getPreviewObserver({ settings, effectToDom })
         observer.observe(previewBox, {
             childList: true,
             subtree: true

--- a/src/features/target-blank/contentScripts/startPreviewBoxObserve.ts
+++ b/src/features/target-blank/contentScripts/startPreviewBoxObserve.ts
@@ -1,0 +1,15 @@
+import { TargetBlankSettings } from "../types";
+import { SELECTOR, getPreviewObserver } from "./domAdapter";
+import { effectsDom } from "./effectsDom";
+
+export const startPreviewBoxObserve = (settings: TargetBlankSettings) => {
+    const previewBox = document.querySelector(SELECTOR.previewWrapper);
+
+    if (previewBox) {
+        const observer = getPreviewObserver({ settings, effectsDom })
+        observer.observe(previewBox, {
+            childList: true,
+            subtree: true
+        })
+    }
+}

--- a/src/features/target-blank/hooks/localSettingsReducer.test.ts
+++ b/src/features/target-blank/hooks/localSettingsReducer.test.ts
@@ -55,6 +55,23 @@ describe('target-blank > reducer', () => {
         expect(actual2).toEqual(expected2)
     })
 
+    test("isOpenOtherTabInPreview のみBooleanの値で更新する", () => {
+        const expected1: State = {
+            ...initialState,
+            isOpenOtherTabInPreview: false
+        }
+
+        const actual1 = localSettingsReducer(initialState, { type: "setIsOpenOtherTabInPreview", payload: false })
+        expect(actual1).toEqual(expected1)
+
+        const expected2: State = {
+            ...initialState,
+            isOpenOtherTabInPreview: true
+        }
+        const actual2 = localSettingsReducer(initialState, { type: "setIsOpenOtherTabInPreview", payload: true })
+        expect(actual2).toEqual(expected2)
+    })
+
     test("excludeUrlInput のみString（URL）の値で更新する", () => {
         const expected1: State = {
             ...initialState,

--- a/src/features/target-blank/hooks/localSettingsReducer.test.ts
+++ b/src/features/target-blank/hooks/localSettingsReducer.test.ts
@@ -4,6 +4,7 @@ describe('target-blank > reducer', () => {
     let initialState: State = {
         alwaysOpenOtherTab: false,
         inKibelaLinkOpenSameTab: false,
+        isOpenOtherTabInPreview: false,
         excludeUrlInput: "",
         excludeUrlList: [],
         excludeUrlInputValidation: "",
@@ -13,6 +14,7 @@ describe('target-blank > reducer', () => {
         initialState = {
             alwaysOpenOtherTab: false,
             inKibelaLinkOpenSameTab: false,
+            isOpenOtherTabInPreview: false,
             excludeUrlInput: "",
             excludeUrlList: [],
             excludeUrlInputValidation: "",

--- a/src/features/target-blank/hooks/localSettingsReducer.ts
+++ b/src/features/target-blank/hooks/localSettingsReducer.ts
@@ -3,6 +3,7 @@ import { ExcludeUrl } from "../types";
 export type Action =
     { type: 'setAlwaysOpenOtherTab', payload: boolean } |
     { type: 'setInKibelaLinkOpenSameTab', payload: boolean } |
+    { type: 'setIsOpenOtherTabInPreview', payload: boolean } |
     { type: 'setExcludeUrlInputValidation', payload: string } |
     { type: 'setExcludeUrlInput', payload: string } |
     { type: "setExcludeUrlList", payload: ExcludeUrl[] }
@@ -11,6 +12,7 @@ export type Action =
 export type State = {
     alwaysOpenOtherTab: boolean;
     inKibelaLinkOpenSameTab: boolean;
+    isOpenOtherTabInPreview: boolean;
     excludeUrlInput: string;
     excludeUrlList: ExcludeUrl[];
     excludeUrlInputValidation: string;
@@ -27,6 +29,12 @@ export const localSettingsReducer = (state: State, action: Action): State => {
         return {
             ...state,
             inKibelaLinkOpenSameTab: action.payload
+        }
+    }
+    if (action.type === "setIsOpenOtherTabInPreview") {
+        return {
+            ...state,
+            isOpenOtherTabInPreview: action.payload
         }
     }
     if (action.type === "setExcludeUrlInputValidation") {

--- a/src/features/target-blank/types/index.ts
+++ b/src/features/target-blank/types/index.ts
@@ -1,6 +1,7 @@
 export type TargetBlankSettings = {
     alwaysOpenOtherTab: boolean
     inKibelaLinkOpenSameTab: boolean
+    isOpenOtherTabInPreview: boolean
     excludeUrlList: ExcludeUrl[]
 }
 

--- a/src/features/target-blank/types/index.ts
+++ b/src/features/target-blank/types/index.ts
@@ -9,3 +9,17 @@ export type ExcludeUrl = {
     url: string;
     host: string;
 };
+
+export type DOMElement = {
+    href: string,
+    className: string,
+    idName: string,
+    isSameSiteLink: boolean,
+    isUserMention: boolean,
+    isAnchorLink: boolean,
+    hasTargetBlank: boolean,
+    setTargetBlankAttribute: (e: Element) => void,
+    rawElement: Element,
+}
+
+export type EffectsDomFunction = ({ elements, settings }: { elements: DOMElement[], settings: TargetBlankSettings }) => void

--- a/src/features/target-blank/utils/getSettingsAboutTargetBlank.ts
+++ b/src/features/target-blank/utils/getSettingsAboutTargetBlank.ts
@@ -8,11 +8,13 @@ export const getSettingsAboutTargetBlank: () => Promise<TargetBlankSettings> = (
             const result: TargetBlankSettings = targetBlankSettings ? {
                 alwaysOpenOtherTab: targetBlankSettings.alwaysOpenOtherTab ?? true,
                 inKibelaLinkOpenSameTab: targetBlankSettings.inKibelaLinkOpenSameTab ?? false,
-                excludeUrlList: targetBlankSettings.excludeUrlList ?? []
+                isOpenOtherTabInPreview: targetBlankSettings.isOpenOtherTabInPreview ?? true,
+                excludeUrlList: targetBlankSettings.excludeUrlList ?? [],
             } : {
                 alwaysOpenOtherTab: true,
                 inKibelaLinkOpenSameTab: false,
-                excludeUrlList: []
+                isOpenOtherTabInPreview: true,
+                excludeUrlList: [],
             }
             return resolve(result)
         })

--- a/src/features/target-blank/utils/initializeState.ts
+++ b/src/features/target-blank/utils/initializeState.ts
@@ -15,4 +15,8 @@ export const initializeState = async (dispatch: React.Dispatch<Action>) => {
         type: 'setExcludeUrlList',
         payload: targetBlankSettings.excludeUrlList,
     });
+    dispatch({
+        type: "setIsOpenOtherTabInPreview",
+        payload: targetBlankSettings.isOpenOtherTabInPreview,
+    });
 };

--- a/src/features/target-blank/utils/setChromeStorage.ts
+++ b/src/features/target-blank/utils/setChromeStorage.ts
@@ -5,6 +5,7 @@ export const setChromeStorage = async ({
     inKibelaLinkOpenSameTab,
     alwaysOpenOtherTab,
     excludeUrlList,
+    isOpenOtherTabInPreview,
 }: TargetBlankSettings) => {
     const targetBlankSettings = await getSettingsAboutTargetBlank();
 
@@ -12,6 +13,7 @@ export const setChromeStorage = async ({
         targetBlankSettings: {
             ...targetBlankSettings,
             inKibelaLinkOpenSameTab,
+            isOpenOtherTabInPreview,
             alwaysOpenOtherTab,
             excludeUrlList,
         },


### PR DESCRIPTION
# 概要

- プレビューモードで間違えてクリックして画面遷移して悲しいことになった事があったので、target-blankを設定できるように機能追加
  - プレビューモードでも有効にするかは、あまりに超大作の記事の場合、エディタの動作がが重くなる可能性があるので選択式にする（でも、もしかしたらChrome拡張は本来のDOMのレンダリングブロックはしなくて動作に影響はないかも？）

<img width="319" alt="image" src="https://user-images.githubusercontent.com/16623885/160276910-a8dc4159-e67f-496e-8a28-0fd31a1d8839.png">

## 技術的要項

- `MutationObserver` を利用して、プレビュー画面のDOM変更を検知し、再取得→target-blank設定を行っている
- 合わせて、 `setTargetBlank ` 関数内部の見通しを良くするために以下の対応を行った
  - 不要に露出していた変数のカプセル化
  - NodeListの変換ロジックの関数化
  - MutationObserver取得ロジックの関数化
- プレビューモードで有効にするかの設定UIの追加
  - 合わせてテスト追加