### PR TITLE
fix: GitHub Actionsのパス指定にミスが有ってキャッシュ利用の場合に必ず落ちていたのを修正

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/cache@v2
         id: node_modules-cache
         with:
-          path: frontend/node_modules
+          path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/cache@v2
         id: node_modules-cache
         with:
-          path: frontend/node_modules
+          path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -26,4 +26,4 @@ jobs:
       - name: yarn type-check
         id: run_type_check
         run: |
-          yarn type-check
+          yarn tsc --noEmit


### PR DESCRIPTION
# 概要

タイトルの通り